### PR TITLE
Fix command line build for macOS

### DIFF
--- a/examples/common/bot_examples.cc
+++ b/examples/common/bot_examples.cc
@@ -665,7 +665,7 @@ void ProtossMultiplayerBot::ManageArmy() {
                             break;
                         }
                         Point2D blink_location = startLocation_;
-                        if (observation->GetPreviousUnit(unit.tag) > 0 && unit.shield < 1) {
+                        if (observation->GetPreviousUnit(unit.tag) != nullptr && unit.shield < 1) {
                             if (!unit.orders.empty()) {
                                 if (target_unit != nullptr) {
                                     Vector2D diff = unit.pos - target_unit->pos;


### PR DESCRIPTION
When try to build in command line on macOS (`cmake` without generating Xcode project then `make`), the build will fail with some errors.

### Errors in this repo

This pull request fixes an error in the examples.

### Erros in the contribs

There are also two errors in one of the dependencies:

```
/s2client-api/contrib/civetweb/src/civetweb.c:141:34: error: unknown warning group '-Wno-reserved-id-macro', ignored [-Werror,-Wunknown-warning-option]
#pragma clang diagnostic ignored "-Wno-reserved-id-macro"
                                 ^
/s2client-api/contrib/civetweb/src/civetweb.c:142:34: error: unknown warning group '-Wno-keyword-macro', ignored [-Werror,-Wunknown-warning-option]
#pragma clang diagnostic ignored "-Wno-keyword-macro"
                                 ^
```

When I try to build `KevinCalderone/civetweb` separately, these two errors appear as warnings, not sure why they are errors when build in `s2client-api`. Any ideas?