### PR TITLE
Fixing Blink Stalker logic in bot_examples

### DIFF
--- a/examples/common/bot_examples.cc
+++ b/examples/common/bot_examples.cc
@@ -665,7 +665,7 @@ void ProtossMultiplayerBot::ManageArmy() {
                             break;
                         }
                         Point2D blink_location = startLocation_;
-                        if (observation->GetPreviousUnit(unit.tag) != nullptr && unit.shield < 1) {
+                        if (observation->GetPreviousUnit(unit.tag)->shield > 0 && unit.shield < 1) {
                             if (!unit.orders.empty()) {
                                 if (target_unit != nullptr) {
                                     Vector2D diff = unit.pos - target_unit->pos;

--- a/examples/common/bot_examples.cc
+++ b/examples/common/bot_examples.cc
@@ -665,7 +665,7 @@ void ProtossMultiplayerBot::ManageArmy() {
                             break;
                         }
                         Point2D blink_location = startLocation_;
-                        if (observation->GetPreviousUnit(unit.tag)->shield > 0 && unit.shield < 1) {
+                        if (old_unit->shield > 0 && unit.shield < 1) {
                             if (!unit.orders.empty()) {
                                 if (target_unit != nullptr) {
                                     Vector2D diff = unit.pos - target_unit->pos;


### PR DESCRIPTION
The original intention of this was to check if you had lost shields recently and blink away then, instead of blinking whenever your shields were at zero. 