### PR TITLE
Fix the height map rendering for the feature_layers example.

### DIFF
--- a/examples/feature_layers.cc
+++ b/examples/feature_layers.cc
@@ -17,11 +17,18 @@ void DrawFeatureLayer1BPP(const SC2APIProtocol::ImageData& image_data, int off_x
     sc2::renderer::Matrix1BPP(image_data.data().c_str(), width, height, off_x, off_y, kPixelDrawSize, kPixelDrawSize);
 }
 
-void DrawFeatureLayer8BPP(const SC2APIProtocol::ImageData& image_data, int off_x, int off_y) {
+void DrawFeatureLayerUnits8BPP(const SC2APIProtocol::ImageData& image_data, int off_x, int off_y) {
     assert(image_data.bits_per_pixel() == 8);
     int width = image_data.size().x();
     int height = image_data.size().y();
-    sc2::renderer::Matrix8BPP(image_data.data().c_str(), width, height, off_x, off_y, kPixelDrawSize, kPixelDrawSize);
+    sc2::renderer::Matrix8BPPPlayers(image_data.data().c_str(), width, height, off_x, off_y, kPixelDrawSize, kPixelDrawSize);
+}
+
+void DrawFeatureLayerHeightMap8BPP(const SC2APIProtocol::ImageData& image_data, int off_x, int off_y) {
+    assert(image_data.bits_per_pixel() == 8);
+    int width = image_data.size().x();
+    int height = image_data.size().y();
+    sc2::renderer::Matrix8BPPHeightMap(image_data.data().c_str(), width, height, off_x, off_y, kPixelDrawSize, kPixelDrawSize);
 }
 
 class RenderAgent : public sc2::Agent {
@@ -34,11 +41,11 @@ public:
         const SC2APIProtocol::Observation* observation = Observation()->GetRawObservation();
 
         const SC2APIProtocol::FeatureLayers& m = observation->feature_layer_data().renders();
-        DrawFeatureLayer8BPP(m.unit_density(), 0, 0);
+        DrawFeatureLayerUnits8BPP(m.unit_density(), 0, 0);
         DrawFeatureLayer1BPP(m.selected(), kDrawSize, 0);
 
         const SC2APIProtocol::FeatureLayersMinimap& mi = observation->feature_layer_data().minimap_renders();
-        DrawFeatureLayer8BPP(mi.height_map(), 0, kDrawSize);
+        DrawFeatureLayerHeightMap8BPP(mi.height_map(), 0, kDrawSize);
         DrawFeatureLayer1BPP(mi.camera(), kDrawSize, kDrawSize);
 
         sc2::renderer::Render();

--- a/include/sc2renderer/sc2_renderer.h
+++ b/include/sc2renderer/sc2_renderer.h
@@ -6,7 +6,8 @@ namespace renderer {
     void Initialize(const char* title, int x, int y, int w, int h, unsigned int flags = 0);
     void Shutdown();
     void Matrix1BPP(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h);
-    void Matrix8BPP(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h);
+    void Matrix8BPPHeightMap(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h);
+    void Matrix8BPPPlayers(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h);
     void ImageRGB(const char* bytes, int width, int height, int off_x, int off_y);
     void Render();
 }

--- a/src/sc2renderer/sc2_renderer.cc
+++ b/src/sc2renderer/sc2_renderer.cc
@@ -69,7 +69,25 @@ void Matrix1BPP(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, i
     }
 }
 
-void Matrix8BPP(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h) {
+void Matrix8BPPHeightMap(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h) {
+    assert(renderer_);
+    assert(window_);
+
+    SDL_Rect rect = CreateRect(0, 0, px_w, px_h);
+    for (size_t y = 0; y < h_mat; ++y) {
+        for (size_t x = 0; x < w_mat; ++x) {
+            rect.x = off_x + (int(x) * rect.w);
+            rect.y = off_y + (int(y) * rect.h);
+
+            // Renders the height map in grayscale [0-255]
+            size_t index = x + y * w_mat;
+            SDL_SetRenderDrawColor(renderer_, bytes[index], bytes[index], bytes[index], 255);
+            SDL_RenderFillRect(renderer_, &rect);
+        }
+    }
+}
+
+void Matrix8BPPPlayers(const char* bytes, int w_mat, int h_mat, int off_x, int off_y, int px_w, int px_h) {
     assert(renderer_);
     assert(window_);
 


### PR DESCRIPTION
For the "feature_layers" project, the height map renderer appeared to be using the same one used to render units for specific players. This resulted in some incorrect colors displaying in the height map - which happened to match the player ID from the incorrect renderer used. Most of these were displayed black though, providing incorrect visual information of the map.

This splits the Matrix8BPP function into two:
1. Matrix8BPPPlayers (to be used as before for unit rendering)

2. Matrix8BPPHeightMap (which renders the grayscale image). Per the [sc2client-proto docs](https://github.com/Blizzard/s2client-proto/blob/master/s2clientprotocol/spatial.proto) for the height map, these byte values are scaled to [0, 255].