### PR TITLE
Updated "Units" to a class instead of a typedef

### DIFF
--- a/include/sc2api/sc2_unit.h
+++ b/include/sc2api/sc2_unit.h
@@ -180,7 +180,17 @@ public:
     operator Tag() const { return tag; }
 };
 
-typedef std::vector<Unit> Units;
+class Units : public std::vector<Unit> {
+public:
+    operator std::vector<Tag>() const {
+        std::vector<Tag> tags;
+        for (auto& unit : *this) {
+            tags.push_back(unit.tag);
+        }
+        return tags;
+    }
+};
+
 typedef std::unordered_map<Tag, size_t> UnitIdxMap;
 
 //! Determines if the unit matches the unit type.

--- a/tests/test_unit_command.cc
+++ b/tests/test_unit_command.cc
@@ -1681,7 +1681,7 @@ namespace sc2 {
             });
 
             if (!marauders_loaded_) {
-                act->UnitCommand(GetTagListFromUnits(test_marauder_units), ABILITY_ID::SMART, test_unit_);
+                act->UnitCommand(test_marauder_units, ABILITY_ID::SMART, test_unit_);
                 marauders_loaded_ = true;
             }
 

--- a/tests/test_unit_command_common.cc
+++ b/tests/test_unit_command_common.cc
@@ -63,15 +63,6 @@ namespace sc2 {
         return offset_point;
     }
 
-    std::vector<Tag> TestUnitCommand::GetTagListFromUnits(Units units) {
-        std::vector<Tag> tags;
-        for (const auto& unit : units) {
-            tags.push_back(unit.tag);
-        }
-
-        return tags;
-    }
-
     void TestUnitCommand::SetOriginPoint() {
         const GameInfo& game_info = agent_->Observation()->GetGameInfo();
         origin_pt_ = FindCenterOfMap(game_info);
@@ -222,7 +213,7 @@ namespace sc2 {
         VerifyOwnerOfUnits(test_units_);
 
         if (test_units_.size() > 1) {
-            act->UnitCommand(GetTagListFromUnits(test_units_), test_ability_);
+            act->UnitCommand(test_units_, test_ability_);
         }
         else {
             act->UnitCommand(test_unit_, test_ability_);
@@ -260,7 +251,7 @@ namespace sc2 {
         }
 
         if (test_units_.size() > 1) {
-            act->UnitCommand(GetTagListFromUnits(test_units_), test_ability_, target_point_);
+            act->UnitCommand(test_units_, test_ability_, target_point_);
         }
         else {
             act->UnitCommand(test_unit_, test_ability_, target_point_);
@@ -307,7 +298,7 @@ namespace sc2 {
         }
 
         if (test_units_.size() > 1) {
-            act->UnitCommand(GetTagListFromUnits(test_units_), test_ability_, target_unit_);
+            act->UnitCommand(test_units_, test_ability_, target_unit_);
         }
         else {
             act->UnitCommand(test_unit_, test_ability_, target_unit_);

--- a/tests/test_unit_command_common.h
+++ b/tests/test_unit_command_common.h
@@ -38,7 +38,6 @@ namespace sc2 {
         virtual void AdditionalTestSetup();
         virtual void IssueUnitCommand(ActionInterface* act);
         virtual Point2D GetPointOffsetX(Point2D starting_point, float offset = 5);
-        virtual std::vector<Tag> GetTagListFromUnits(Units units);
         virtual void SetOriginPoint();
         virtual void SetTestTime();
         virtual void VerifyUnitOrders(Tag unit_tag, ABILITY_ID test_ability);


### PR DESCRIPTION
This allows it to be converted to `std::vector<Tag>` without a custom method.

Makes batching of unit commands much simpler as you don't have to manually extract the `Unit`s or `Tag`s to your `UnitCommand` methods, can just pass through the `Units` variable directly.

Updated tests that used a similar method. All tests ran successfully after changes.