### PR TITLE
Cleaning up MSVC warnings on C4456

### DIFF
--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -89,7 +89,7 @@ int LaunchProcess(ProcessSettings& process_settings, Client* client, int window_
 int LaunchProcesses(ProcessSettings& process_settings, std::vector<Client*> clients, int window_width, int window_height, int window_start_x, int window_start_y) {
     int last_port = 0;
     // Start an sc2 process for each bot.
-    int i = 0;
+    int clientIndex = 0;
     for (auto c : clients) {
         last_port = LaunchProcess(process_settings, 
             c, 
@@ -98,7 +98,7 @@ int LaunchProcesses(ProcessSettings& process_settings, std::vector<Client*> clie
             window_start_x, 
             window_start_y, 
             process_settings.port_start + static_cast<int>(process_settings.process_info.size()) - 1, 
-            i++);
+            clientIndex++);
     }
 
     // Since connect is blocking do it after the processes are launched.
@@ -480,8 +480,8 @@ bool CoordinatorImp::StartGame() {
     assert(starcraft_started_);
 
     // Create the game with the first client.
-    Agent* c = agents_.front();
-    bool is_game_created = c->Control()->CreateGame(game_settings_.map_name, game_settings_.player_setup, process_settings_.realtime);
+    Agent* firstClient = agents_.front();
+    bool is_game_created = firstClient->Control()->CreateGame(game_settings_.map_name, game_settings_.player_setup, process_settings_.realtime);
     assert(is_game_created);
 
     int i = 0;

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -323,8 +323,8 @@ bool Convert(const ResponseObservationPtr& response_observation_ptr, RawActions&
             action.target_point.y = action_raw_command.target_world_space_pos().y();
         }
 
-        for (int i = 0; i < action_raw_command.unit_tags_size(); ++i)
-            action.unit_tags.push_back(action_raw_command.unit_tags(i));
+        for (int j = 0; j < action_raw_command.unit_tags_size(); ++j)
+            action.unit_tags.push_back(action_raw_command.unit_tags(j));
 
         // TODO: Add optional target positions.
         // optional Point target_world_space_pos = 2;
@@ -396,8 +396,8 @@ bool Convert(const ResponseObservationPtr& response_observation_ptr, SpatialActi
             const SC2APIProtocol::ActionSpatialUnitSelectionRect& action_select = action_FL.unit_selection_rect();
 
             SpatialSelectRect select;
-            for (int i = 0; i < action_select.selection_screen_coord_size(); ++i) {
-                const SC2APIProtocol::RectangleI& rect_proto = action_select.selection_screen_coord(i);
+            for (int j = 0; j < action_select.selection_screen_coord_size(); ++j) {
+                const SC2APIProtocol::RectangleI& rect_proto = action_select.selection_screen_coord(j);
 
                 Rect2DI rect;
                 rect.from.x = rect_proto.p0().x();


### PR DESCRIPTION
This cleans up some minor warnings under MSVC on [C4456](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4456) (declaration of X hides previous local definition).

Note: This warning isn't on by default, but was found when bumping the warning level to 4 in the projects (/W4).