### PR TITLE
Cleaning up MSVC warnings on C4100

### DIFF
--- a/examples/common/bot_examples.cc
+++ b/examples/common/bot_examples.cc
@@ -223,7 +223,7 @@ bool MultiplayerBot::FindNearestMineralPatch(const Point2D& start, Tag& target) 
 
 // Tries to find a random location that can be pathed to on the map.
 // Returns 'true' if a new, random location has been found that is pathable by the unit.
-bool MultiplayerBot::FindEnemyPosition(Tag tag, Point2D& target_pos) {
+bool MultiplayerBot::FindEnemyPosition(Tag, Point2D& target_pos) {
     if (game_info_.enemy_start_locations.empty()) {
         return false;
     }
@@ -1111,7 +1111,7 @@ void ProtossMultiplayerBot::ConvertGateWayToWarpGate() {
     }
 }
 
-bool ProtossMultiplayerBot::TryBuildStructureNearPylon(AbilityID ability_type_for_structure, UnitTypeID unit_type) {
+bool ProtossMultiplayerBot::TryBuildStructureNearPylon(AbilityID ability_type_for_structure, UnitTypeID) {
     const ObservationInterface* observation = Observation();
 
     //Need to check to make sure its a pylon instead of a warp prism
@@ -3017,7 +3017,7 @@ void TerranBot::OnGameStart() {
 
 // Tries to find a random location that can be pathed to on the map.
 // Returns 'true' if a new, random location has been found that is pathable by the unit.
-bool TerranBot::FindEnemyPosition(Tag tag, Point2D& target_pos) {
+bool TerranBot::FindEnemyPosition(Tag, Point2D& target_pos) {
     if (game_info_.enemy_start_locations.empty()) return false;
     target_pos = game_info_.enemy_start_locations.front();
     return true;

--- a/examples/echo_actions.cc
+++ b/examples/echo_actions.cc
@@ -22,7 +22,7 @@ public:
         last_echoed_gameloop_ = 0;
     }
 
-    void EchoAction(const sc2::RawActions& actions, sc2::DebugInterface* debug, const sc2::Abilities& abilities) {
+    void EchoAction(const sc2::RawActions& actions, sc2::DebugInterface* debug, const sc2::Abilities&) {
         if (actions.size() < 1) {
             debug->DebugTextOut(last_action_text_);
             return;

--- a/examples/tutorial.cc
+++ b/examples/tutorial.cc
@@ -1,3 +1,3 @@
-int main(int argc, char* argv[]) {
+int main(int /*argc*/, char* /*argv*/[]) {
     return 0;
 }

--- a/include/sc2api/sc2_client.h
+++ b/include/sc2api/sc2_client.h
@@ -57,26 +57,26 @@ public:
 
     //! Called whenever one of the player's units has been destroyed.
     //!< \param unit The destroyed unit.
-    virtual void OnUnitDestroyed(const Unit& unit) {}
+    virtual void OnUnitDestroyed(const Unit&) {}
 
     //! Called when a Unit has been created by the player.
     //!< \param unit The created unit.
-    virtual void OnUnitCreated(const Unit& unit) {}
+    virtual void OnUnitCreated(const Unit&) {}
 
     //! Called when a unit becomes idle, this will only occur as an event so will only be called when the unit becomes
     //! idle and not a second time. Being idle is defined by having orders in the previous step and not currently having
     //! orders or if it did not exist in the previous step and now does, a unit being created, for instance, will call both
     //! OnUnitCreated and OnUnitIdle if it does not have a rally set.
     //!< \param unit The idle unit.
-    virtual void OnUnitIdle(const Unit& unit) {}
+    virtual void OnUnitIdle(const Unit&) {}
 
     //! Called when an upgrade is finished, warp gate, ground weapons, baneling speed, etc.
     //!< \param upgrade The completed upgrade.
-    virtual void OnUpgradeCompleted(UpgradeID upgrade) {}
+    virtual void OnUpgradeCompleted(UpgradeID) {}
 
     //! Called when the unit in the previous step had a build progress less than 1.0 but is greater than or equal to 1.0 in the current step.
     //!< \param unit The constructed unit.
-    virtual void OnBuildingConstructionComplete(const Unit& unit) {}
+    virtual void OnBuildingConstructionComplete(const Unit&) {}
 
     //! Called when a nydus is placed.
     virtual void OnNydusDetected() {}
@@ -86,10 +86,10 @@ public:
 
     //! Called when an enemy unit enters vision from out of fog of war.
     //!< \param unit The unit entering vision.
-    virtual void OnUnitEnterVision(const Unit& unit) {}
+    virtual void OnUnitEnterVision(const Unit&) {}
 
     //! Called for various errors the library can encounter. See ClientError enum for possible errors.
-    virtual void OnError(const std::vector<ClientError>& client_errors, const std::vector<std::string>& protocol_errors = {}) {}
+    virtual void OnError(const std::vector<ClientError>& /*client_errors*/, const std::vector<std::string>& /*protocol_errors*/ = {}) {}
 };
 
 //! The base class for Agent and ReplayObserver.

--- a/src/sc2api/sc2_agent.cc
+++ b/src/sc2api/sc2_agent.cc
@@ -251,7 +251,7 @@ void ActionFeatureLayerImp::Select(const Point2DI& center, PointSelectionType se
     select_pt->set_type(static_cast<SC2APIProtocol::ActionSpatialUnitSelectionPoint_Type>(selection_type));
 }
 
-void ActionFeatureLayerImp::Select(const Point2DI& p0, const Point2DI& p1, bool add_to_selection) {
+void ActionFeatureLayerImp::Select(const Point2DI& p0, const Point2DI& p1, bool /*add_to_selection*/) {
     SC2APIProtocol::RequestAction* request_action = GetRequestAction();
     SC2APIProtocol::Action* action = request_action->add_actions();
     SC2APIProtocol::ActionSpatial* action_feature_layer = action->mutable_action_feature_layer();

--- a/src/sc2api/sc2_connection.cc
+++ b/src/sc2api/sc2_connection.cc
@@ -61,7 +61,7 @@ bool GetClientData(const mg_connection* connection, sc2::Connection*& out) {
 
 static int DataHandler(
     mg_connection* conn,
-    int flags,
+    int /*flags*/,
     char* data,
     size_t data_len,
     void*) {

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -294,7 +294,7 @@ bool Convert(const ObservationPtr& observation_ptr, RenderedFrame& render) {
     return true;
 }
 
-bool Convert(const ResponseObservationPtr& response_observation_ptr, RawActions& actions, const Units& units, uint32_t player_id) {
+bool Convert(const ResponseObservationPtr& response_observation_ptr, RawActions& actions, const Units& /*units*/, uint32_t /*player_id*/) {
     for (int i = 0; i < response_observation_ptr->actions_size(); ++i) {
         const SC2APIProtocol::Action& proto_action = response_observation_ptr->actions(i);
         if (!proto_action.has_action_raw()) {
@@ -345,7 +345,7 @@ bool Convert(const SC2APIProtocol::ActionSpatialUnitSelectionPoint::Type& type_p
     return false;
 }
 
-bool Convert(const ResponseObservationPtr& response_observation_ptr, SpatialActions& actions, const Units& units, uint32_t player_id) {
+bool Convert(const ResponseObservationPtr& response_observation_ptr, SpatialActions& actions, const Units& /*units*/, uint32_t /*player_id*/) {
     for (int i = 0; i < response_observation_ptr->actions_size(); ++i) {
         const SC2APIProtocol::Action& proto_action = response_observation_ptr->actions(i);
         if (!proto_action.has_action_feature_layer()) {

--- a/src/sc2api/sc2_replay_observer.cc
+++ b/src/sc2api/sc2_replay_observer.cc
@@ -227,7 +227,7 @@ ReplayControlInterface* ReplayObserver::ReplayControl() {
     return replay_control_imp_;
 }
 
-bool ReplayObserver::IgnoreReplay(const ReplayInfo& replay_info, uint32_t& player_id) {
+bool ReplayObserver::IgnoreReplay(const ReplayInfo& replay_info, uint32_t& /*player_id*/) {
     // Ignore games less than 30 seconds.
     static const float MinimumReplayDuration = 30.0f;
     if (replay_info.duration < MinimumReplayDuration) {

--- a/src/sc2utils/sc2_manage_process.cc
+++ b/src/sc2utils/sc2_manage_process.cc
@@ -148,7 +148,7 @@ std::string GetGameMapsDirectory(const std::string& process_path) {
     return result;
 }
 
-BOOL WINAPI ConsoleHandlerRoutine(DWORD dwCtrlType) {
+BOOL WINAPI ConsoleHandlerRoutine(DWORD /*dwCtrlType*/) {
     while (windows_processes.size()) {
         uint64_t pid = static_cast<uint64_t>(windows_processes[windows_processes.size() - 1].pi_.dwProcessId);
         if (!TerminateProcess(pid))

--- a/tests/test_framework.h
+++ b/tests/test_framework.h
@@ -57,7 +57,7 @@ protected:
     virtual void OnTestsEnd () = 0;
     virtual void OnPostStep () {}
 
-    void OnError(const std::vector<ClientError>& client_errors, const std::vector<std::string>& protocol_errors = {}) override { success_ = false; }
+    void OnError(const std::vector<ClientError>& /*client_errors*/, const std::vector<std::string>& /*protocol_errors*/ = {}) override { success_ = false; }
 
 private:
     void OnGameStart() final;

--- a/tests/test_unit_command.cc
+++ b/tests/test_unit_command.cc
@@ -1341,7 +1341,7 @@ namespace sc2 {
             }
         }
 
-        void VerifyUnitIdleAfterOrder(UNIT_TYPEID unit_type) override {}
+        void VerifyUnitIdleAfterOrder(UNIT_TYPEID) override {}
     };
 
 

--- a/tests/test_unit_command_common.cc
+++ b/tests/test_unit_command_common.cc
@@ -55,7 +55,7 @@ namespace sc2 {
 
     void TestUnitCommand::AdditionalTestSetup() {}
 
-    void TestUnitCommand::IssueUnitCommand(ActionInterface* act) {}
+    void TestUnitCommand::IssueUnitCommand(ActionInterface*) {}
 
     Point2D TestUnitCommand::GetPointOffsetX(Point2D starting_point, float offset) {
         Point2D offset_point = starting_point;


### PR DESCRIPTION
This cleans up some minor warnings under MSVC on [C4100](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100) (unused formal parameters).

Note: This warning isn't on by default, but was found when bumping the warning level to 4 in the projects (/W4).

Note2: These changes try to follow the [unused guidelines](https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions) in Google's style guide. Changes might be somewhat subjective on when to comment versus removing the identifier.