### PR TITLE
Cleaning up MSVC warning signed/unsigned conversion

### DIFF
--- a/src/sc2utils/sc2_manage_process.cc
+++ b/src/sc2utils/sc2_manage_process.cc
@@ -238,7 +238,7 @@ bool TerminateProcess(uint64_t process_id) {
     if (index < 0)
         return false;
 
-    ::TerminateProcess(windows_processes[index].pi_.hProcess, -1);
+    ::TerminateProcess(windows_processes[index].pi_.hProcess, static_cast<UINT>(-1));
     WaitForSingleObject(windows_processes[index].pi_.hProcess, 120 * 1000);
 
     process_id = 0LL;


### PR DESCRIPTION
This cleans up a minor warning on an implicit signed -> unsigned conversion. This appears to be intended, so adding an explicit cast.