### PR TITLE
Bump warning level from 3 to 4. Enable warning-to-error conversion.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,10 @@ endforeach()
 
 
 if (WIN32)
+    set_target_properties(sc2api PROPERTIES COMPILE_FLAGS "/W4 /WX")
+    set_target_properties(sc2lib PROPERTIES COMPILE_FLAGS "/W4 /WX")
+    set_target_properties(sc2renderer PROPERTIES COMPILE_FLAGS "/W4 /WX")
+    set_target_properties(sc2utils PROPERTIES COMPILE_FLAGS "/W3 /WX")
     set_target_properties(sc2protocol PROPERTIES COMPILE_FLAGS "/W0")
 endif (WIN32)
 


### PR DESCRIPTION
This bumps the warning level under MSVC from 3 to 4 for the core sc2api, sc2lib and sc2renderer projects. Additionally, this turns on warning to error conversion to purposefully fail compilation if warnings are discovered on the sc2api, sc2lib, sc2renderer or sc2utils projects.

The following projects weren't updated:
- sc2utils: Warnings on dirent.h cause this to still use /W3
- sc2protocol: Contains generated protobuf code (this is usually difficult to lock down)
- examples/*: These are likely to change enough that it may not warrant turning on warn-to-error (users may want to mess around more with this code when experimenting - we shouldn't limit them too much)
- all_tests: This can probably be updated in a future change (an existing cast warning will need to be resolved)

Note: This requires PR #81 to be applied for sc2utils to build warning-free on /W3.