### PR TITLE
Cleanup some manual resource management and for-loops

### DIFF
--- a/src/sc2api/sc2_agent.cc
+++ b/src/sc2api/sc2_agent.cc
@@ -272,12 +272,12 @@ void ActionFeatureLayerImp::Select(const Point2DI& p0, const Point2DI& p1, bool 
 class AgentControlImp : public AgentControlInterface {
 public:
     ControlInterface* control_interface_;
-    ActionImp* actions_;
-    ActionFeatureLayerImp* actions_feature_layer_;
+    std::unique_ptr<ActionImp> actions_;
+    std::unique_ptr<ActionFeatureLayerImp> actions_feature_layer_;
     Agent* agent_;
 
     AgentControlImp(Agent* agent, ControlInterface* control_interface);
-    ~AgentControlImp();
+    ~AgentControlImp() = default;
 
     bool Restart() override;
 };
@@ -286,13 +286,8 @@ AgentControlImp::AgentControlImp(Agent* agent, ControlInterface* control_interfa
     control_interface_(control_interface),
     actions_(nullptr),
     agent_(agent) {
-    actions_ = new ActionImp(control_interface_->Proto(), *control_interface);
-    actions_feature_layer_ = new ActionFeatureLayerImp(control_interface_->Proto(), *control_interface);
-}
-
-AgentControlImp::~AgentControlImp() {
-    delete actions_;
-    delete actions_feature_layer_;
+    actions_ = std::make_unique<ActionImp>(control_interface_->Proto(), *control_interface);
+    actions_feature_layer_ = std::make_unique<ActionFeatureLayerImp>(control_interface_->Proto(), *control_interface);
 }
 
 bool AgentControlImp::Restart() {
@@ -338,11 +333,11 @@ Agent::~Agent() {
 }
 
 ActionInterface* Agent::Actions() {
-    return agent_control_imp_->actions_;
+    return agent_control_imp_->actions_.get();
 }
 
 ActionFeatureLayerInterface* Agent::ActionsFeatureLayer() {
-    return agent_control_imp_->actions_feature_layer_;
+    return agent_control_imp_->actions_feature_layer_.get();
 }
 
 AgentControlInterface* Agent::AgentControl() {

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -1234,13 +1234,12 @@ void DebugImp::SendDebug() {
         unit_value->set_unit_tag(set_unit_value.tag);
     }
 
-    for (std::size_t i = 0; i < debug_state_.size(); ++i) {
+    for (const SC2APIProtocol::DebugGameState& state : debug_state_) {
         SC2APIProtocol::DebugCommand* command = request_debug->add_debug();
-        command->set_game_state(debug_state_[i]);
+        command->set_game_state(state);
     }
 
-    for (const DebugUnit& unit : debug_unit_)
-    {
+    for (const DebugUnit& unit : debug_unit_) {
         if (unit.count < 1) {
             continue;
         }


### PR DESCRIPTION
This cleans up some code with more C++11 style:

- Some manual memory management around the PIMPL pointers can use unique_ptr. Note that some of the raw memory management can't be switch to unique_ptr, due to the lack of a known type in the header. If this is desired, I believe shared_ptr works in such cases.
- Minor refactoring around some raw loops, particularly some cleanup when constructing threads in a vector

Note: This was only checked under MSVC, did not build/test against GCC/Clang.