### PR TITLE
Enable parallel compilation at the project level under MSVC

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,9 @@ file(GLOB common_sources "common/*.h" "common/*.cc")
 include_directories(SYSTEM "${PROJECT_BINARY_DIR}/generated")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/contrib/SDL-mirror/include")
 
+# Setup MSVC parallelized builds
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
+
 #bot_simple
 add_executable(bot_simple "bot_simple.cc")
 set_target_properties(bot_simple PROPERTIES FOLDER examples)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,8 @@ endforeach()
 # Now include that directory
 include_directories(SYSTEM "${PROJECT_BINARY_DIR}/generated")
 
+# Setup MSVC parallelized builds
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
 
 # Create the library
 add_library(sc2api ${sources_sc2})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,9 @@ file(GLOB test_SRC
     "*.cc"
 )
 
+# Setup MSVC parallelized builds
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
+
 #all_tests
 add_executable(all_tests ${test_SRC})
 set_target_properties(all_tests PROPERTIES FOLDER tests)


### PR DESCRIPTION
On my i7-6700HQ (8 cores, hyperthreading) this drops full debug x64 builds from 116 seconds to 88 seconds.