### PR TITLE
Add map_name to GameInfo

### DIFF
--- a/include/sc2api/sc2_map_info.h
+++ b/include/sc2api/sc2_map_info.h
@@ -67,6 +67,8 @@ struct PlayerInfo {
 
 //! Initial data for a game and map.
 struct GameInfo {
+    //! Plain text name of a map. Note that this may be different from the filename of the map.
+    std::string map_name;
     //! World width of a map.
     int width;
     //! World height of a map.

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -457,6 +457,7 @@ bool Convert(const ResponseGameInfoPtr& response_game_info_ptr, GameInfo& game_i
     if (!start_raw.has_map_size() || !start_raw.map_size().has_x() || !start_raw.map_size().has_y()) {
         return false;
     }
+    game_info.map_name = response_game_info_ptr->map_name();
     game_info.width = static_cast<int>(start_raw.map_size().x());
     game_info.height = static_cast<int>(start_raw.map_size().y());
 


### PR DESCRIPTION
Adds map_name to GameInfo. Will be useful in conjunction with the sc2ai.net bot ladder. My bot specifically needs it to load map specific training data from text files.

I would also suggest changing game_settings_.map_name to game_settings_.map_path to avoid confusion. map_name will almost never match the map filename. For example, the map_name may contain spaces, and does not usually include the .SC2Map file extension.

game_settings_.map_name does not appear to be publicly exposed, so it should be safe to change. There is already an inconsistancy in Coordinator::StartGame. map_path is passed into the function, and map_name is set to it.