### PR TITLE
Add local_map_path to GameInfo

### DIFF
--- a/include/sc2api/sc2_map_info.h
+++ b/include/sc2api/sc2_map_info.h
@@ -69,6 +69,8 @@ struct PlayerInfo {
 struct GameInfo {
     //! Plain text name of a map. Note that this may be different from the filename of the map.
     std::string map_name;
+    //! Filename of map. Includes the ".SC2Map" file extension.
+    std::string local_map_path;
     //! World width of a map.
     int width;
     //! World height of a map.

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -458,6 +458,7 @@ bool Convert(const ResponseGameInfoPtr& response_game_info_ptr, GameInfo& game_i
         return false;
     }
     game_info.map_name = response_game_info_ptr->map_name();
+    game_info.local_map_path = response_game_info_ptr->local_map_path();
     game_info.width = static_cast<int>(start_raw.map_size().x());
     game_info.height = static_cast<int>(start_raw.map_size().y());
 


### PR DESCRIPTION
I'm not sure I got the documentation correct for local_map_path. My understanding is that local_map_path is simply the filename of the map, and never a complete path. 