### PR TITLE
change cmake windows target in documentation

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -32,7 +32,7 @@ git clone --recursive https://github.com/Blizzard/s2client-api
 cd s2client-api
 mkdir build
 cd build
-cmake ../ -G "Visual Studio 15 Win64"
+cmake ../ -G "Visual Studio 15 2017 Win64"
 start s2client-api.sln
 ```
 


### PR DESCRIPTION
According to [CMake 3.9.4](https://cmake.org/cmake/help/v3.9/generator/Visual%20Studio%2015%202017.html) generator platform should be `Visual Studio 15 2017 Win64`