### PR TITLE
make -eglpath relative on linux

### DIFF
--- a/examples/rendered.cc
+++ b/examples/rendered.cc
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
 #if LINUX_USE_SOFTWARE_RENDER
     coordinator.AddCommandLine("-osmesapath /usr/lib/x86_64-linux-gnu/libOSMesa.so");
 #else
-    coordinator.AddCommandLine("-eglpath /usr/lib/nvidia-384/libEGL.so");
+    coordinator.AddCommandLine("-eglpath libEGL.so");
 #endif
 #endif
 

--- a/tests/test_rendered.cc
+++ b/tests/test_rendered.cc
@@ -117,7 +117,7 @@ bool TestRendered(int argc, char** argv) {
     coordinator.SetRender(settings);
 
 #if defined(__linux__)
-    coordinator.AddCommandLine("-eglpath /usr/lib/nvidia-367/libEGL.so");
+    coordinator.AddCommandLine("-eglpath libEGL.so");
 #endif
 
     // Add the custom bot, it will control the players.


### PR DESCRIPTION
Previously the libEGL.so path was hardcoded to `/usr/lib/nvidia-384/libEGL.so`. The typical location, I believe, is `/usr/lib/libEGL.so`, so this prevents the renderer from starting.

I think the right solution is to not hard code the path at all and just let the system resolve the link. Changing these two lines fixes the `rendered` example for me (I'm on Arch Linux with an Nvidia card and proprietary Nvidia drivers), and running `all_tests` shows everything as passing.