### PR TITLE
Allow the user to refresh the GameInfo if needed.

### DIFF
--- a/include/sc2api/sc2_interfaces.h
+++ b/include/sc2api/sc2_interfaces.h
@@ -136,6 +136,7 @@ public:
     virtual const Effects& GetEffectData(bool force_refresh = false) const = 0;
 
     //! Gets the GameInfo struct for the current map.
+	//!< \param force_refresh forces a full query from the game, may otherwise cache data from a previous call.
     //!< \return The current GameInfo struct.
     virtual const GameInfo& GetGameInfo(bool force_refresh = false) const = 0;
 

--- a/include/sc2api/sc2_interfaces.h
+++ b/include/sc2api/sc2_interfaces.h
@@ -137,7 +137,7 @@ public:
 
     //! Gets the GameInfo struct for the current map.
     //!< \return The current GameInfo struct.
-    virtual const GameInfo& GetGameInfo() const = 0;
+    virtual const GameInfo& GetGameInfo(bool force_refresh = false) const = 0;
 
     //! The mineral count of the player.
     //!< \return The mineral count.

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -104,7 +104,7 @@ public:
     const Upgrades& GetUpgradeData(bool force_refresh = false) const final;
     const Buffs& GetBuffData(bool force_refresh = false) const final;
     const Effects& GetEffectData(bool force_refresh = false) const final;
-    const GameInfo& GetGameInfo() const final;
+	const GameInfo& GetGameInfo(bool force_refresh = false) const final;
     bool HasCreep(const Point2D& point) const final;
     Visibility GetVisibility(const Point2D& point) const final;
     bool IsPathable(const Point2D& point) const final;
@@ -404,7 +404,11 @@ const Effects& ObservationImp::GetEffectData(bool force_refresh) const {
     return effect_ids_;
 }
 
-const GameInfo& ObservationImp::GetGameInfo() const {
+const GameInfo& ObservationImp::GetGameInfo(bool force_refresh) const {
+	if (force_refresh) {
+		game_info_cached_ = false;
+	}
+
     if (game_info_cached_) {
         return game_info_;
     }


### PR DESCRIPTION
While reviewing some replays, I noticed, that the map names didn't change in the GameInfo object. I figured out that this object doesn't seem to be refreshed when loading a new replay so I just added the possibility to force a refresh for this object.