### PR TITLE
Allow other replay perspective than player 1 in replay.

### DIFF
--- a/include/sc2api/sc2_coordinator.h
+++ b/include/sc2api/sc2_coordinator.h
@@ -90,6 +90,9 @@ public:
     //! ability ids are generalized to BUILD_TECHLAB ability id in the observation.
     void SetUseGeneralizedAbilityId(bool value);
 
+    //! Sets the replay perspective. 0 to observe "Everyone"
+    void SetReplayPerspective(int perspective=1);
+
     //! Appends a command line argument to be fed to StarCraft II when starting.
     // \param option The string to be appended to the executable invoke.
     void AddCommandLine(const std::string& option);

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -922,9 +922,12 @@ void Coordinator::SetUseGeneralizedAbilityId(bool value) {
     imp_->use_generalized_ability_id = value;
 }
 
+void Coordinator::SetReplayPerspective(int perspective) {
+    imp_->replay_settings_.player_id = perspective;
+}
+
 bool Coordinator::SetReplayPath(const std::string& path) {
     imp_->replay_settings_.replay_file.clear();
-
     if (HasExtension(path, ".SC2Replay")) {
         imp_->replay_settings_.replay_file.push_back(path);
     }


### PR DESCRIPTION
In some cases you want to observe both players at once or from the second player perspective. I could not find a way to change the perspective so I added a function to do so. Ideally, it would be an additional parameter for one of the other replay related functions but I couldn't find a good fit.

Regards