### PR TITLE
Make function robust to existing command structure

### DIFF
--- a/src/sc2lib/sc2_search.cc
+++ b/src/sc2lib/sc2_search.cc
@@ -103,6 +103,21 @@ std::vector<Point3D> CalculateExpansionLocations(const ObservationInterface* obs
     }
 
     std::vector<bool> results = query->Placement(queries);
+    // Edit the results : allow to build in command structure existing location
+    Units commandStructures = observation->GetUnits(
+        [](const Unit& unit) {
+        return unit.unit_type == UNIT_TYPEID::TERRAN_COMMANDCENTER || unit.unit_type == UNIT_TYPEID::TERRAN_ORBITALCOMMAND || unit.unit_type == UNIT_TYPEID::TERRAN_PLANETARYFORTRESS ||
+            unit.unit_type == UNIT_TYPEID::PROTOSS_NEXUS ||
+            unit.unit_type == UNIT_TYPEID::ZERG_HATCHERY || unit.unit_type == UNIT_TYPEID::ZERG_LAIR || unit.unit_type == UNIT_TYPEID::ZERG_HIVE;
+    });
+    for (auto cc : commandStructures) {
+        for (int i = 0; i < queries.size(); ++i) {
+            if (DistanceSquared2D(cc->pos, queries[i].target_pos) < 1.0f) {
+                results[i] = true;
+            }
+        }
+    }
+    
     size_t start_index = 0;
     for (int i = 0; i < clusters.size(); ++i) {
         std::pair<Point3D, std::vector<Unit> >& cluster = clusters[i];


### PR DESCRIPTION
If there is already a building, or, e.g. creep in a location, the placement queries for a CommandCenter (line 19) will answer false.
In the onStart method of a bot, it is likely that your own initial base is blocking at least one expansion location. This led to the algorithm returning points way off the map, or in e.g. (0,0). With this patch, we a posteriori edit the results of the query, so that an existing CC/Hatch/Nexus still counts as a good location to build in.