### PR TITLE
fix one off expansion positions

### DIFF
--- a/src/sc2lib/sc2_search.cc
+++ b/src/sc2lib/sc2_search.cc
@@ -117,7 +117,13 @@ std::vector<Point3D> CalculateExpansionLocations(const ObservationInterface* obs
 
             Point2D& p = queries[j].target_pos;
 
-            float d = Distance2D(p, cluster.first);
+            float d = 0;
+            // avoid using the cog of the cluster, it might produce candidates that are one off
+            // instead sum distances to all minerals/gas in the cluster
+            for (auto resource : cluster.second) {
+                // distance squared is faster and does not change min/max results
+                d += DistanceSquared2D(p, resource);
+            }
             if (d < distance) {
                 distance = d;
                 closest = p;

--- a/src/sc2lib/sc2_search.cc
+++ b/src/sc2lib/sc2_search.cc
@@ -120,9 +120,9 @@ std::vector<Point3D> CalculateExpansionLocations(const ObservationInterface* obs
             float d = 0;
             // avoid using the cog of the cluster, it might produce candidates that are one off
             // instead sum distances to all minerals/gas in the cluster
-            for (auto resource : cluster.second) {
+            for (const auto & resource : cluster.second) {
                 // distance squared is faster and does not change min/max results
-                d += DistanceSquared2D(p, resource);
+                d += DistanceSquared2D(p, resource.pos);
             }
             if (d < distance) {
                 distance = d;


### PR DESCRIPTION
On some maps, expansions were placed one off by the current algorithm.
The problem is that the cog of the cluster might be off center wrt to the position we want. 
The sum of distances is safe, it will force to stick to the right zone.