### PR TITLE
Prevent TerminateProcess(0)

### DIFF
--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -197,7 +197,9 @@ CoordinatorImp::CoordinatorImp() :
 
 CoordinatorImp::~CoordinatorImp() {
     for (auto& p : process_settings_.process_info) {
-        TerminateProcess(p.process_id);
+        if (p.process_id > 0) {
+            TerminateProcess(p.process_id);
+        }
     }
 }
 


### PR DESCRIPTION
In a proxy setting the process_id usually referring to the game instances is default initialized to 0. On Linux based systems, during the destruction of the `sc2::coordinator`, `TerminateProcess(0)` will kill all processes within the bot's processing group, including the bot itself. This is probably not intended behavior and can have unwanted side effects.