### PR TITLE
A very small problem in feature_layer example

### DIFF
--- a/examples/feature_layers.cc
+++ b/examples/feature_layers.cc
@@ -41,7 +41,7 @@ public:
         const SC2APIProtocol::Observation* observation = Observation()->GetRawObservation();
 
         const SC2APIProtocol::FeatureLayers& m = observation->feature_layer_data().renders();
-        DrawFeatureLayerUnits8BPP(m.unit_density(), 0, 0);
+        DrawFeatureLayerUnits8BPP(m.player_relative(), 0, 0);
         DrawFeatureLayer1BPP(m.selected(), kDrawSize, 0);
 
         const SC2APIProtocol::FeatureLayersMinimap& mi = observation->feature_layer_data().minimap_renders();

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -740,7 +740,7 @@ void Coordinator::LaunchStarcraft() {
 void Coordinator::Connect(int port) {
     while (imp_->process_settings_.process_info.size() < imp_->agents_.size()) {
         imp_->process_settings_.process_info.push_back(
-            ProcessInfo(imp_->process_settings_.net_address, 0, port)
+            ProcessInfo(imp_->process_settings_.net_address, 0, port++)
         );
     }
 

--- a/src/sc2renderer/sc2_renderer.cc
+++ b/src/sc2renderer/sc2_renderer.cc
@@ -111,7 +111,7 @@ void Matrix8BPPPlayers(const char* bytes, int w_mat, int h_mat, int off_x, int o
                 SDL_SetRenderDrawColor(renderer_, 0, 255, 0, 255);
                 break;
             case 2:
-                // Enemy.
+                // Ally.
                 SDL_SetRenderDrawColor(renderer_, 255, 0, 0, 255);
                 break;
             case 3:
@@ -119,6 +119,7 @@ void Matrix8BPPPlayers(const char* bytes, int w_mat, int h_mat, int off_x, int o
                 SDL_SetRenderDrawColor(renderer_, 0, 0, 255, 255);
                 break;
             case 4:
+                // Enemy
                 SDL_SetRenderDrawColor(renderer_, 255, 255, 0, 255);
                 break;
             case 5:


### PR DESCRIPTION
There is a small problem in feature_layer example.
As you can see from the comments of DrawFeatureLayerUnits8BPP() that this function is used for drawing which player the units belong to.
But the first argument passed to it is m.unit_density.
further more, the comments in this function are little wrong, too.