### PR TITLE
sc2api : Update Convert CloakState

### DIFF
--- a/include/sc2api/sc2_unit.h
+++ b/include/sc2api/sc2_unit.h
@@ -93,6 +93,8 @@ public:
 
     //! Unit cloak state.
     enum CloakState {
+        //! Under the fog, so unknown whether it's cloaked or not.
+        CloakedUnknown = 0,
         //! Cloaked, invisible to enemies until detected.
         Cloaked = 1,
         //! Cloaked enemy, but detected.

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -149,6 +149,7 @@ bool Convert(const SC2APIProtocol::Alliance& alliance_proto, Unit::Alliance& all
 
 bool Convert(const SC2APIProtocol::CloakState& cloak_proto, Unit::CloakState& cloak) {
     switch (cloak_proto) {
+        case SC2APIProtocol::CloakState::CloakedUnknown:  cloak = Unit::CloakedUnknown; return true;
         case SC2APIProtocol::CloakState::Cloaked:         cloak = Unit::Cloaked; return true;
         case SC2APIProtocol::CloakState::CloakedDetected: cloak = Unit::CloakedDetected; return true;
         case SC2APIProtocol::CloakState::NotCloaked:      cloak = Unit::NotCloaked; return true;


### PR DESCRIPTION
There is an issue with receiving of the observation object (#301).

Particularly, received data is converted to unit pool in the sc2_proto_to_pods.cc file. And the conversion function checks that received data is correct and all units are in known state.

For some reason the game sets flag has_cloak and send CloakState as CloakedUnknown.
Conversion routine did not take it into account and returned status failure. So that, unit pool stays not initialized.

This request adds new cloak state CloakedUnknown and updates the conversion routine, so it returns success in such case,