### PR TITLE
CloakState and AbilityID fixes.

### DIFF
--- a/include/sc2api/sc2_typeenums.h
+++ b/include/sc2api/sc2_typeenums.h
@@ -478,7 +478,8 @@ namespace sc2 {
         HARVEST_RETURN_MULE = 167,   // Target: None.
         HARVEST_RETURN_PROBE = 299,   // Target: None.
         HARVEST_RETURN_SCV = 296,   // Target: None.
-        HOLDPOSITION = 18,    // Target: None.
+//      HOLDPOSITION = 18,    // Target: None.
+        HOLDPOSITION = 3793,
         LAND = 3678,  // Target: Point.
         LAND_BARRACKS = 554,   // Target: Point.
         LAND_COMMANDCENTER = 419,   // Target: Point.
@@ -531,8 +532,10 @@ namespace sc2 {
         MORPH_WARPGATE = 1518,  // Target: None.
         MORPH_WARPPRISMPHASINGMODE = 1528,  // Target: None.
         MORPH_WARPPRISMTRANSPORTMODE = 1530,  // Target: None.
-        MOVE = 16,    // Target: Unit, Point.
-        PATROL = 17,    // Target: Unit, Point.
+        // MOVE = 16,    // Target: Unit, Point.
+        MOVE = 3794,
+        //  PATROL = 17,    // Target: Unit, Point.
+        PATROL = 3795,
         RALLY_BUILDING = 195,   // Target: Unit, Point.
         RALLY_COMMANDCENTER = 203,   // Target: Unit, Point.
         RALLY_HATCHERY_UNITS = 211,   // Target: Unit, Point.

--- a/include/sc2api/sc2_unit.h
+++ b/include/sc2api/sc2_unit.h
@@ -101,7 +101,7 @@ public:
         CloakedDetected = 2,
         //! No cloaking.
         NotCloaked = 3,
-        //! Cloaked ally, though not sure why this is necessary.
+        //! Cloaked ally unit.
         CloakedAllied = 4
     };
 

--- a/include/sc2api/sc2_unit.h
+++ b/include/sc2api/sc2_unit.h
@@ -101,8 +101,8 @@ public:
         CloakedDetected = 2,
         //! No cloaking.
         NotCloaked = 3,
-        //! Could not determine cloaking state.
-        Unknown = 4
+        //! Cloaked ally, though not sure why this is necessary.
+        CloakedAllied = 4
     };
 
     //! If the unit is shown on screen or not.

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -153,6 +153,7 @@ bool Convert(const SC2APIProtocol::CloakState& cloak_proto, Unit::CloakState& cl
         case SC2APIProtocol::CloakState::Cloaked:         cloak = Unit::Cloaked; return true;
         case SC2APIProtocol::CloakState::CloakedDetected: cloak = Unit::CloakedDetected; return true;
         case SC2APIProtocol::CloakState::NotCloaked:      cloak = Unit::NotCloaked; return true;
+        case SC2APIProtocol::CloakState::CloakedAllied:    cloak = Unit::CloakedAllied; return true;
     }
     return false;
 }
@@ -190,7 +191,7 @@ bool Convert(const ObservationRawPtr& observation_raw, UnitPool& unit_pool, uint
             }
         }
         else {
-            unit->cloak = Unit::Unknown;
+            unit->cloak = Unit::CloakedUnknown;
         }
 
         unit->detect_range = observation_unit.detect_range();

--- a/tests/test_unit_command.cc
+++ b/tests/test_unit_command.cc
@@ -1637,7 +1637,7 @@ namespace sc2 {
         }
 
         void AdditionalTestSetup() override {
-            agent_->Debug()->DebugCreateUnit(UNIT_TYPEID::TERRAN_MARAUDER, origin_pt_, agent_->Observation()->GetPlayerID(), 3);
+            agent_->Debug()->DebugCreateUnit(UNIT_TYPEID::TERRAN_MARAUDER, origin_pt_, agent_->Observation()->GetPlayerID(), 2);
             agent_->Debug()->SendDebug();
         }
 

--- a/tests/test_unit_command.cc
+++ b/tests/test_unit_command.cc
@@ -294,6 +294,9 @@ namespace sc2 {
     //
     // TestBuildGateway
     //
+    // Since 2018 revamp, new gateways autobuild as warpgates.
+    // Should test this on base tech level instead of debug tech level.
+    // Instead we'll just hack around for now.
 
     class TestBuildGateway : public TestUnitCommandTargetingPoint {
     public:
@@ -309,18 +312,18 @@ namespace sc2 {
 
         void AdditionalTestSetup() override {
             target_point_ = GetPointOffsetX(origin_pt_);
-
+            
             agent_->Debug()->DebugCreateUnit(UNIT_TYPEID::PROTOSS_PYLON, origin_pt_, agent_->Observation()->GetPlayerID(), 1);
             agent_->Debug()->SendDebug();
         }
 
         void OnTestFinish() override {
-            VerifyUnitExistsAndComplete(UNIT_TYPEID::PROTOSS_GATEWAY);
+            VerifyUnitExistsAndComplete(UNIT_TYPEID::PROTOSS_WARPGATE);
             VerifyUnitIdleAfterOrder(test_unit_type_);
-            VerifyUnitIdleAfterOrder(UNIT_TYPEID::PROTOSS_GATEWAY);
+            VerifyUnitIdleAfterOrder(UNIT_TYPEID::PROTOSS_WARPGATE);
             const ObservationInterface* obs = agent_->Observation();
-            if (obs->GetWarpGateCount() != 0) {
-                ReportError("Gateway is being incorrectly identified as a Warp Gate.");
+            if (obs->GetWarpGateCount() != 1) {
+                ReportError("New gateway is not being identified as a Warp Gate.");
             }
             KillAllUnits();
         }
@@ -1555,7 +1558,7 @@ namespace sc2 {
         TestTransportBunkerLoad() {
             test_unit_type_ = UNIT_TYPEID::TERRAN_BUNKER;
             target_unit_type_ = UNIT_TYPEID::TERRAN_MARAUDER;
-            test_ability_ = ABILITY_ID::LOAD;
+            test_ability_ = ABILITY_ID::LOAD_BUNKER;
             instant_cast_ = true;
         }
 
@@ -1601,7 +1604,7 @@ namespace sc2 {
             if (test_unit_ && test_unit_->passengers.size() != 1) {
                 ReportError("Unit count in bunker is not 1.");
             }
-            if (test_unit_ && test_unit_->cargo_space_max != 6) {
+            if (test_unit_ && test_unit_->cargo_space_max != 8) {
                 ReportError("Bunker cargo space max is not correct.");
             }
             if (test_unit_ && test_unit_->cargo_space_taken != 2) {
@@ -1625,7 +1628,7 @@ namespace sc2 {
         TestTransportBunkerUnloadAll() {
             test_unit_type_ = UNIT_TYPEID::TERRAN_BUNKER;
             target_unit_type_ = UNIT_TYPEID::TERRAN_MARAUDER;
-            test_ability_ = ABILITY_ID::UNLOADALL;
+            test_ability_ = ABILITY_ID::UNLOADALL_BUNKER;
             instant_cast_ = true;
         }
 
@@ -1684,7 +1687,7 @@ namespace sc2 {
             if (test_unit_ && test_unit_->passengers.size() != 0) {
                 ReportError("Unit count in bunker is not 0.");
             }
-            if (test_unit_ && test_unit_->cargo_space_max != 6) {
+            if (test_unit_ && test_unit_->cargo_space_max != 8) {
                 ReportError("Bunker cargo space max is not correct.");
             }
             if (test_unit_ && test_unit_->cargo_space_taken != 0) {

--- a/tests/test_unit_command.cc
+++ b/tests/test_unit_command.cc
@@ -39,7 +39,7 @@ namespace sc2 {
                 ReportError("Could not find the test unit.");
             }
 
-            if (test_unit_ && test_unit_->cloak != Unit::CloakState::Cloaked) {
+            if (test_unit_ && test_unit_->cloak != Unit::CloakState::CloakedAllied) {
                 ReportError("Unit is not cloaked as expected.");
             }
 
@@ -1254,9 +1254,6 @@ namespace sc2 {
 
             if (target_units.front()->is_blip != true) {
                 ReportError("Target unit is not a blip.");
-            }
-            if (target_units.front()->cloak != Unit::CloakState::Unknown) {
-                ReportError("Target unit cloak state is incorrect.");
             }
             if (target_units.front()->display_type != Unit::DisplayType::Hidden) {
                 ReportError("Target unit is not hidden.");


### PR DESCRIPTION
Builds on @piroxiljin changes to fixes issue #315 (and probably a bunch of other Observation issues)

A number of issue were introduced by the most recent major balance changes.
This pull request attempts to fix:
- Mishandling of the cloak state.
- Remapping of some ability id's

Additionally, unit tests have been updated to reflect:
- bigger bunkers
- gateways automatically building as warpgates.