### PR TITLE
Fix the problem that GetGameLoop() doesn't return the right loop number in the frame just after Control()->Restart()

### DIFF
--- a/src/sc2api/sc2_agent.cc
+++ b/src/sc2api/sc2_agent.cc
@@ -344,6 +344,7 @@ bool AgentControlImp::Restart() {
         return false;
     }
 
+    agent_->Control()->GetObservation();
     agent_->OnGameStart();
 
     return control_interface_->IsInGame();


### PR DESCRIPTION
Just added `Control()->GetObservation();` in `AgentControlImp::Restart()`